### PR TITLE
replaced disappeared gem with its rescued clone

### DIFF
--- a/smartermeter.gemspec
+++ b/smartermeter.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
   s.add_dependency('mechanize', ["= 1.0.0"])
-  s.add_dependency('crypt19', ["= 1.2.1"])
+  s.add_dependency('crypt19-rb', ["= 1.2.1"])
   s.add_dependency('rest-client', ["= 1.6.1"])
   s.add_dependency('json_pure', ["= 1.5.1"])
   s.add_dependency('rubyzip', ["= 0.9.5"])


### PR DESCRIPTION
The crypt19 gem has disappeared. No idea why. This replaces it with the rescued version, which has a slightly different name, but appears to be otherwise unchanged.

The rescued gem: https://github.com/coffeejunk/crypt19
Twitter discussion: https://twitter.com/gabrielgironda/status/309412732455759872
